### PR TITLE
SVG support, QR codes in share box, and other tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,23 +1,51 @@
 YOURLS QR Code Plugin
 =====================
 
-Allows you to get the QR code by simply clicking on a button in the Admin area (or by adding `.qr` to the end of the keyword.)
+Allows you to get the QR code by simply clicking on a button in the Admin area (or by adding `.qr` to the end of the short URL. Can also optionally display a QR code in the share box. 
+
+QR codes can be configured to be either PNG or SVG format by default. Appending the extension `.svg` or `.png` to the URL will force the format.
 
 Installation
 ------------
 
-Move the `seans-qrcode` folder into the `/users/plugins` folder. Then, activate the plugin in the admin interface. That's all there is to it.
+Move the `seans-qrcode` folder into the `/users/plugins` folder. Then, activate the plugin in the admin interface. That's all there is to it, but see Configuration below
 
 Requirements
 ------------
 
-User must have [YOURLS](http://yourls.org/#Install) 1.5.1+ installed.
+User must have [YOURLS](http://yourls.org/#Install) 1.5.1+ installed. Latest version is tested with YOURLS 1.7.1.
 
 **WARNING**: Does not work with YOURLS 1.6.
 
 In addition to the [server requirements of YOURLS](http://yourls.org/#requirement), make sure you follow the [server requirements of PHP QR Code library](http://sourceforge.net/p/phpqrcode/code/HEAD/tree/branches/www/1.1.4/INSTALL).
 
 If these requirements can't be met, but you can install and run YOURLS, try the [Google Chart API QR Code Plugin](https://github.com/YOURLS/YOURLS/wiki/Plugin-%3D-QRCode-ShortURL) from Ozh (YOURL's developer).
+
+Configuration
+-------------
+
+The plugin requires no special configuration, but there are a few options that you can control by defining constants in `user/config.php`, e.g.
+
+
+```php
+define("SEAN_QR_WIDTH", 250);
+```
+
+### SEAN_QR_WIDTH
+_Interger. Default: 200._  
+The width (and height) of the generated QR code in pixels. For PNG this will be approximate.
+
+### SEAN_QR_ADD_TO_SHAREBOX
+_Boolean. Default: false._  
+Whether to include a QR code in the share boxes. Set to true to enable.
+
+### SEAN_QR_DEFAULT_FMT
+_String. 'png' or 'svg'. Default: png._  
+The default format to generate QR codes in. This can be overridden be adding the appropriate extension to the QR code's URL. eg `http://mydomain.com/bleh.qr.svg` or `http://mydomain.com/bleh.qr.png`
+
+### SEAN_QR_MARGIN
+_Interger. Default: 2._  
+The width of the margin (quiet zone) around the QR, in 'virtual pixels'. A value of 4 is generally recommended, but if you are using the QR context where it is surrounded by white space anyway lower values may work fine.
 
 Bonus
 -----
@@ -29,4 +57,4 @@ Credits
 
 Main functionality of adding a QR code is borrowed from [Ozh's orginal plugin code](https://github.com/YOURLS/YOURLS/wiki/Plugin-%3D-QRCode-ShortURL).
 
-QR code generation made possible by [PHP QR Code](http://phpqrcode.sourceforge.net/) (Google's own QR Code generation, through the Chart Image API [is depreciated](http://googledevelopers.blogspot.com/2012/04/changes-to-deprecation-policies-and-api.html) and will no longer be developed).
+QR code generation made possible by [PHP QR Code](http://phpqrcode.sourceforge.net/) (Google's own QR Code generation, through the Chart Image API [is deprecated](http://googledevelopers.blogspot.com/2012/04/changes-to-deprecation-policies-and-api.html) and will no longer be developed).

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The default format to generate QR codes in. This can be overridden be adding the
 
 ### SEAN_QR_MARGIN
 _Interger. Default: 2._  
-The width of the margin (quiet zone) around the QR, in 'virtual pixels'. A value of 4 is generally recommended, but if you are using the QR context where it is surrounded by white space anyway lower values may work fine.
+The width of the margin (quiet zone) around the QR, in 'virtual pixels'. A value of 4 is generally recommended, but if you are using the QR code in a context where it is surrounded by white space anyway lower values may work fine.
 
 Bonus
 -----

--- a/seans-qrcode/phpqrcode.php
+++ b/seans-qrcode/phpqrcode.php
@@ -36,8 +36,8 @@
  
 
 /*
- * Version: 1.1.4
- * Build: 2010100721
+ * Version: 1.9.9
+ * Build: 20130526
  */
 
 
@@ -57,7 +57,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -74,32 +74,53 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
-	// Encoding modes
-	 
-	define('QR_MODE_NUL', -1);
-	define('QR_MODE_NUM', 0);
-	define('QR_MODE_AN', 1);
-	define('QR_MODE_8', 2);
-	define('QR_MODE_KANJI', 3);
-	define('QR_MODE_STRUCTURE', 4);
 
-	// Levels of error correction.
+    /** \defgroup QR_CONST Global Constants
+    Constant used globally for function arguments.
+    Make PHP calls a little bit more clear, in place of missing (in dynamicaly typed language) enum types.
+    * @{ 
+    */
+     
+    /** @name QR-Code Encoding Modes */
+    /** @{ */
+    
+    /** null encoding, used when no encoding was speciffied yet */
+    define('QR_MODE_NUL', -1);   
+    /** Numerical encoding, only numbers (0-9) */	
+    define('QR_MODE_NUM', 0);   
+    /** AlphaNumerical encoding, numbers (0-9) uppercase text (A-Z) and few special characters (space, $, %, *, +, -, ., /, :) */    
+    define('QR_MODE_AN', 1);  
+    /** 8-bit encoding, raw 8 bit encoding */
+    define('QR_MODE_8', 2);    
+    /** Kanji encoding */	
+    define('QR_MODE_KANJI', 3);    
+    /** Structure, internal encoding for structure-related data */	
+    define('QR_MODE_STRUCTURE', 4); 
+    /**@}*/
 
-	define('QR_ECLEVEL_L', 0);
-	define('QR_ECLEVEL_M', 1);
-	define('QR_ECLEVEL_Q', 2);
-	define('QR_ECLEVEL_H', 3);
-	
-	// Supported output formats
-	
-	define('QR_FORMAT_TEXT', 0);
-	define('QR_FORMAT_PNG',  1);
-	
-	class qrstr {
-		public static function set(&$srctab, $x, $y, $repl, $replLen = false) {
-			$srctab[$y] = substr_replace($srctab[$y], ($replLen !== false)?substr($repl,0,$replLen):$repl, $x, ($replLen !== false)?$replLen:strlen($repl));
-		}
-	}	
+    /** @name QR-Code Levels of Error Correction 
+    Constants speciffy ECC level from lowest __L__ to the highest __H__. 
+    Higher levels are recomended for Outdoor-presented codes, but generates bigger codes.
+    */
+    /** @{*/
+	/** ~7% of codewords can be restored */
+    define('QR_ECLEVEL_L', 0); 
+	/** ~15% of codewords can be restored */
+    define('QR_ECLEVEL_M', 1); 
+	/** ~25% of codewords can be restored */
+    define('QR_ECLEVEL_Q', 2);
+	/** ~30% of codewords can be restored */
+    define('QR_ECLEVEL_H', 3);
+    /** @}*/
+   
+    /** @name QR-Code Supported output formats */
+    /** @{*/
+    define('QR_FORMAT_TEXT', 0);
+    define('QR_FORMAT_PNG',  1);
+    /** @}*/
+    
+    /** @}*/
+
 
 
 
@@ -138,7 +159,7 @@
  * Toolset, handy and debug utilites.
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -155,8 +176,14 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+	/** @addtogroup CoreGroup */
+	/** @{ */
+	
+	/** Helper class */
     class QRtools {
     
+		public static $timeBenchmarkStarted = false;
+	
         //----------------------------------------------------------------------
         public static function binarize($frame)
         {
@@ -255,6 +282,13 @@
             }
         }
         
+		//----------------------------------------------------------------------
+        public static function startTimeBenchmark()
+        {
+			$GLOBALS['qr_time_bench'] = array();
+            self::markTime('start');
+        }
+		
         //----------------------------------------------------------------------
         public static function markTime($markerId)
         {
@@ -265,6 +299,11 @@
                 $GLOBALS['qr_time_bench'] = array();
             
             $GLOBALS['qr_time_bench'][$markerId] = $time;
+			
+			if ((!self::$timeBenchmarkStarted)&&($markerId != 'start')) {
+				self::$timeBenchmarkStarted = true;
+				$GLOBALS['qr_time_bench']['start'] = $time;
+			}
         }
         
         //----------------------------------------------------------------------
@@ -299,9 +338,9 @@
         
     }
     
+	/** @}*/
+	
     //##########################################################################
-    
-    QRtools::markTime('start');
     
 
 
@@ -320,7 +359,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * The following data / specifications are taken from
  * "Two dimensional symbol -- QR-code -- Basic Specification" (JIS X0510:2004)
@@ -343,16 +382,35 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
+    /** Maximal Version no allowed by QR-Code spec */
     define('QRSPEC_VERSION_MAX', 40);
+    /** Maximal Code size in pixels allowed by QR-Code spec */
     define('QRSPEC_WIDTH_MAX',   177);
 
     define('QRCAP_WIDTH',        0);
     define('QRCAP_WORDS',        1);
     define('QRCAP_REMINDER',     2);
     define('QRCAP_EC',           3);
+    
+    /** @addtogroup CoreGroup */
+    /** @{ */
 
+    /** QR-Code specification and Code Frame handling.
+    Contains code specifications, calculates base frame, code structure 
+    and base properties
+    */
     class QRspec {
     
+        /** Array specifying properties of QR-Code "versions". 
+        Each so-called version has specified code area size and capacity. 
+        There are 40 versions, this table specifies for each of them four parameters:
+        
+        - Integer __QRCAP_WIDTH__ - size of code in pixels
+        - Integer __QRCAP_WORDS__ - code capacity, in words
+        - Integer __QRCAP_REMINDER__ - remainder words
+        - Array of Integers __QRCAP_EC__ - RS correction code count for each of four ECC levels
+        \hideinitializer
+        */  
         public static $capacity = array(
             array(  0,    0, 0, array(   0,    0,    0,    0)),
             array( 21,   26, 0, array(   7,   10,   13,   17)), // 1
@@ -398,30 +456,53 @@
         );
         
         //----------------------------------------------------------------------
+        /** Calculates data length for specified code configuration.
+        @param Integer $version Code version
+        @param Integer $level ECC level
+        @returns Code data capacity
+        */
         public static function getDataLength($version, $level)
         {
             return self::$capacity[$version][QRCAP_WORDS] - self::$capacity[$version][QRCAP_EC][$level];
         }
         
         //----------------------------------------------------------------------
+        /** Calculates count of Error Correction Codes for specified code configuration.
+        @param Integer $version Code version
+        @param Integer $level ECC level
+        @returns ECC code count
+        */
         public static function getECCLength($version, $level)
         {
             return self::$capacity[$version][QRCAP_EC][$level];
         }
         
         //----------------------------------------------------------------------
+        /** Gets pixel width of code.
+        @param Integer $version Code version
+        @returns Code width, in pixels
+        */
         public static function getWidth($version)
         {
             return self::$capacity[$version][QRCAP_WIDTH];
         }
         
         //----------------------------------------------------------------------
+        /** Gets reminder chars length.
+        @param Integer $version Code version
+        @returns Reminder length
+        */
         public static function getRemainder($version)
         {
             return self::$capacity[$version][QRCAP_REMINDER];
         }
         
         //----------------------------------------------------------------------
+        /** Finds minimal code version capable of hosting specified data length.
+        @param Integer $size amount of raw data
+        @param Integer $level ECC level
+        @returns code version capable of hosting specified amount of data at specified ECC level
+        */
         public static function getMinimumVersion($size, $level)
         {
 
@@ -435,7 +516,10 @@
         }
     
         //######################################################################
-        
+
+        /** Length bits Table.
+        \hideinitializer
+        */
         public static $lengthTableBits = array(
             array(10, 12, 14),
             array( 9, 11, 13),
@@ -485,8 +569,10 @@
         }
 
         // Error correction code -----------------------------------------------
-        // Table of the error correction code (Reed-Solomon block)
-        // See Table 12-16 (pp.30-36), JIS X0510:2004.
+        /** Table of the error correction code (Reed-Solomon block).
+        @see Table 12-16 (pp.30-36), JIS X0510:2004.
+        \hideinitializer
+        */
 
         public static $eccTable = array(
             array(array( 0,  0), array( 0,  0), array( 0,  0), array( 0,  0)),
@@ -563,12 +649,14 @@
 
         // Alignment pattern ---------------------------------------------------
 
-        // Positions of alignment patterns.
-        // This array includes only the second and the third position of the 
-        // alignment patterns. Rest of them can be calculated from the distance 
-        // between them.
+        /** Positions of alignment patterns.
+        This array includes only the second and the third position of the 
+        lignment patterns. Rest of them can be calculated from the distance 
+        between them.
          
-        // See Table 1 in Appendix E (pp.71) of JIS X0510:2004.
+        @see Table 1 in Appendix E (pp.71) of JIS X0510:2004.
+        \hideinitializer
+        */
          
         public static $alignmentPattern = array(      
             array( 0,  0),
@@ -582,13 +670,12 @@
             array(24, 50), array(28, 54), array(32, 58), array(26, 54), array(30, 58), //35-40
         );                                                                                  
 
-        
-        /** --------------------------------------------------------------------
-         * Put an alignment marker.
-         * @param frame
-         * @param width
-         * @param ox,oy center coordinate of the pattern
-         */
+        //----------------------------------------------------------------------
+        /** Puts an alignment marker.
+        @param frame
+        @param width
+        @param ox,oy center coordinate of the pattern
+        */
         public static function putAlignmentMarker(array &$frame, $ox, $oy)
         {
             $finder = array(
@@ -603,7 +690,7 @@
             $xStart = $ox-2;
             
             for($y=0; $y<5; $y++) {
-                QRstr::set($frame, $xStart, $yStart+$y, $finder[$y]);
+                self::set($frame, $xStart, $yStart+$y, $finder[$y]);
             }
         }
 
@@ -646,12 +733,12 @@
         }
 
         // Version information pattern -----------------------------------------
-
-		// Version information pattern (BCH coded).
-        // See Table 1 in Appendix D (pp.68) of JIS X0510:2004.
+        /** Version information pattern (BCH coded).
+        size: [QRSPEC_VERSION_MAX - 6]
+        @see Table 1 in Appendix D (pp.68) of JIS X0510:2004.
+        \hideinitializer
+        */
         
-		// size: [QRSPEC_VERSION_MAX - 6]
-		
         public static $versionPattern = array(
             0x07c94, 0x085bc, 0x09a99, 0x0a4d3, 0x0bbf6, 0x0c762, 0x0d847, 0x0e60d,
             0x0f928, 0x10b78, 0x1145d, 0x12a17, 0x13532, 0x149a6, 0x15683, 0x168c9,
@@ -669,8 +756,11 @@
             return self::$versionPattern[$version -7];
         }
 
-        // Format information --------------------------------------------------
-        // See calcFormatInfo in tests/test_qrspec.c (orginal qrencode c lib)
+        //----------------------------------------------------------------------
+        /** Format information.
+        @see calcFormatInfo in tests/test_qrspec.c (orginal qrencode c lib)
+        \hideinitializer
+        */
         
         public static $formatInfo = array(
             array(0x77c4, 0x72f3, 0x7daa, 0x789d, 0x662f, 0x6318, 0x6c41, 0x6976),
@@ -691,16 +781,16 @@
         }
 
         // Frame ---------------------------------------------------------------
-        // Cache of initial frames.
-         
+        
+        /** Cache of initial frames. */
         public static $frames = array();
 
-        /** --------------------------------------------------------------------
-         * Put a finder pattern.
-         * @param frame
-         * @param width
-         * @param ox,oy upper-left coordinate of the pattern
-         */
+        /** Put a finder pattern.
+        @param frame
+        @param width
+        @param ox,oy upper-left coordinate of the pattern
+        \hideinitializer
+        */
         public static function putFinderPattern(&$frame, $ox, $oy)
         {
             $finder = array(
@@ -714,7 +804,7 @@
             );                            
             
             for($y=0; $y<7; $y++) {
-                QRstr::set($frame, $ox, $oy+$y, $finder[$y]);
+                self::set($frame, $ox, $oy+$y, $finder[$y]);
             }
         }
 
@@ -742,14 +832,14 @@
             
             $setPattern = str_repeat("\xc0", 8);
             
-            QRstr::set($frame, 0, 7, $setPattern);
-            QRstr::set($frame, $width-8, 7, $setPattern);
-            QRstr::set($frame, 0, $width - 8, $setPattern);
+            self::set($frame, 0, 7, $setPattern);
+            self::set($frame, $width-8, 7, $setPattern);
+            self::set($frame, 0, $width - 8, $setPattern);
         
             // Format info
             $setPattern = str_repeat("\x84", 9);
-            QRstr::set($frame, 0, 8, $setPattern);
-            QRstr::set($frame, $width - 8, 8, $setPattern, 8);
+            self::set($frame, 0, 8, $setPattern);
+            self::set($frame, $width - 8, 8, $setPattern, 8);
             
             $yOffset = $width - 8;
 
@@ -797,6 +887,10 @@
         }
 
         //----------------------------------------------------------------------
+        /** Dumps debug HTML of frame.
+        @param Array $frame code frame
+        @param Boolean $binary_mode in binary mode only contents is dumped, without styling
+        */
         public static function debug($frame, $binary_mode = false)
         {
             if ($binary_mode) {
@@ -806,11 +900,7 @@
                         $frameLine = join('&#9608;&#9608;', explode('1', $frameLine));
                     }
                     
-                    ?>
-                <style>
-                    .m { background-color: white; }
-                </style>
-                <?php
+                    echo '<style> .m { background-color: white; } </style> ';
                     echo '<pre><tt><br/ ><br/ ><br/ >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;';
                     echo join("<br/ >&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;", $frame);
                     echo '</tt></pre><br/ ><br/ ><br/ ><br/ ><br/ ><br/ >';
@@ -818,45 +908,71 @@
             } else {
             
                 foreach ($frame as &$frameLine) {
-                    $frameLine = join('<span class="m">&nbsp;</span>',  explode("\xc0", $frameLine));
-                    $frameLine = join('<span class="m">&#9618;</span>', explode("\xc1", $frameLine));
-                    $frameLine = join('<span class="p">&nbsp;</span>',  explode("\xa0", $frameLine));
-                    $frameLine = join('<span class="p">&#9618;</span>', explode("\xa1", $frameLine));
-                    $frameLine = join('<span class="s">&#9671;</span>', explode("\x84", $frameLine)); //format 0
-                    $frameLine = join('<span class="s">&#9670;</span>', explode("\x85", $frameLine)); //format 1
-                    $frameLine = join('<span class="x">&#9762;</span>', explode("\x81", $frameLine)); //special bit
-                    $frameLine = join('<span class="c">&nbsp;</span>',  explode("\x90", $frameLine)); //clock 0
-                    $frameLine = join('<span class="c">&#9719;</span>', explode("\x91", $frameLine)); //clock 1
-                    $frameLine = join('<span class="f">&nbsp;</span>',  explode("\x88", $frameLine)); //version
-                    $frameLine = join('<span class="f">&#9618;</span>', explode("\x89", $frameLine)); //version
-                    $frameLine = join('&#9830;', explode("\x01", $frameLine));
-                    $frameLine = join('&#8901;', explode("\0", $frameLine));
-                }
                 
-                ?>
-                <style>
-                    .p { background-color: yellow; }
-                    .m { background-color: #00FF00; }
-                    .s { background-color: #FF0000; }
-                    .c { background-color: aqua; }
-                    .x { background-color: pink; }
-                    .f { background-color: gold; }
-                </style>
-                <?php
-                echo "<pre><tt>";
+                    $frameLine = strtr($frameLine, array(
+                        "\xc0" => '<span class="m">&nbsp;</span>',   //marker 0    
+                        "\xc1" => '<span class="m">&#9618;</span>',  //marker 1
+                        "\xa0" => '<span class="p">&nbsp;</span>',   //submarker 0
+                        "\xa1" => '<span class="p">&#9618;</span>',  //submarker 1
+                        "\x84" => '<span class="s">F</span>',        //format 0
+                        "\x85" => '<span class="s">f</span>',        //format 1
+                        "\x81" => '<span class="x">S</span>',        //special bit
+                        "\x90" => '<span class="c">C</span>',        //clock 0
+                        "\x91" => '<span class="c">c</span>',        //clock 1
+                        "\x88" => '<span class="f">&nbsp;</span>',   //version 0 
+                        "\x89" => '<span class="f">&#9618;</span>',  //version 1
+                        "\x03" => '1',                               // 1
+                        "\x02" => '0',                               // 0         
+                    ));                                          
+                }                
+               
+                echo '<style>';
+                echo '    .p { background-color: yellow; }';
+                echo '    .m { background-color: #00FF00; }';
+                echo '    .s { background-color: #FF0000; }';
+                echo '    .c { background-color: aqua; }';
+                echo '    .x { background-color: pink; }';
+                echo '    .f { background-color: gold; }';
+                echo '</style>';
+               
+                echo "<tt>";
                 echo join("<br/ >", $frame);
-                echo "</tt></pre>";
+                echo "<br/>Legend:<br/>";
+                echo '1 - data 1<br/>';                          
+                echo '0 - data 0<br/>';  
+                echo '<span class="m">&nbsp;</span> - marker bit 0<br/>'; 
+                echo '<span class="m">&#9618;</span> - marker bit 1<br/>';  
+                echo '<span class="p">&nbsp;</span> - secondary marker bit 0<br/>';   
+                echo '<span class="p">&#9618;</span> - secondary marker bit 1<br/>';  
+                echo '<span class="s">F</span> - format bit 0<br/>';        
+                echo '<span class="s">f</span> - format bit 1<br/>';        
+                echo '<span class="x">S</span> - special bit<br/>';        
+                echo '<span class="c">C</span> - clock bit 0<br/>';        
+                echo '<span class="c">c</span> - clock bit 1<br/>';        
+                echo '<span class="f">&nbsp;</span> - version bit 0<br/>'; 
+                echo '<span class="f">&#9618;</span> - version bit 1<br/>';
+                echo "</tt>";
             
             }
         }
 
         //----------------------------------------------------------------------
+        /** Serializes frame.
+        Create compressed, serialized version of frame.
+        @param Array $frame Code Frame
+        @return String binary compresed Code Frame
+        */
         public static function serial($frame)
         {
             return gzcompress(join("\n", $frame), 9);
         }
         
         //----------------------------------------------------------------------
+        /** Deserializes frame.
+        Loads frame from serialized compressed binary
+        @param String $code binary, GZipped, serialized frame
+        @return Array Code Frame array
+        */
         public static function unserial($code)
         {
             return explode("\n", gzuncompress($code));
@@ -891,6 +1007,23 @@
         }
 
         //----------------------------------------------------------------------
+        /** Sets code frame with speciffied code.
+        @param Array $frame target frame (modified by reference)
+        @param Integer $x X-axis position of replacement
+        @param Integer $y Y-axis position of replacement
+        @param Byte $repl replacement string
+        @param Integer $replLen (optional) replacement string length, when __Integer__ > 1 subset of given $repl is used, when __false__ whole $repl is used
+        */
+        public static function set(&$frame, $x, $y, $repl, $replLen = false) {
+            $frame[$y] = substr_replace($frame[$y], ($replLen !== false)?substr($repl,0,$replLen):$repl, $x, ($replLen !== false)?$replLen:strlen($repl));
+        }
+        
+        //----------------------------------------------------------------------
+        
+        /** @name Reed-Solomon related shorthand getters.
+        Syntax-sugar to access code speciffication by getter name, not by spec array field.
+        */
+        /** @{*/
         public static function rsBlockNum($spec)     { return $spec[0] + $spec[3]; }
         public static function rsBlockNum1($spec)    { return $spec[0]; }
         public static function rsDataCodes1($spec)   { return $spec[1]; }
@@ -900,8 +1033,12 @@
         public static function rsEccCodes2($spec)    { return $spec[2]; }
         public static function rsDataLength($spec)   { return ($spec[0] * $spec[1]) + ($spec[3] * $spec[4]);    }
         public static function rsEccLength($spec)    { return ($spec[0] + $spec[3]) * $spec[2]; }
-        
+        /** @}*/
     }
+    
+    /** @}*/
+    
+
 
 
 
@@ -916,7 +1053,7 @@
  * Image output of code using GD2
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -935,9 +1072,27 @@
  
     define('QR_IMAGE', true);
 
+
+    /** @defgroup OutputGroup Standard API Output
+    Provide simple Raster & Vector output */
+     
+    /** @addtogroup OutputGroup */
+    /** @{ */
+    
+    /** Image rendering helper.
+    Uses GD2 image to render QR Code into image file */
     class QRimage {
     
         //----------------------------------------------------------------------
+        /**
+        Creates PNG image.
+        @param Array $frame frame containing code
+        @param String $filename (optional) output file name, if __false__ outputs to browser with required headers
+        @param Integer $pixelPerPoint (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $outerFrame (optional) code margin (silent zone) in 'virtual'  pixels
+        @param Boolean $saveandprint (optional) if __true__ code is outputed to browser and saved to file, otherwise only saved to file. It is effective only if $outfile is specified.
+        */
+        
         public static function png($frame, $filename = false, $pixelPerPoint = 4, $outerFrame = 4,$saveandprint=FALSE) 
         {
             $image = self::image($frame, $pixelPerPoint, $outerFrame);
@@ -959,6 +1114,15 @@
         }
     
         //----------------------------------------------------------------------
+        /**
+        Creates JPEG image.
+        @param Array $frame frame containing code
+        @param String $filename (optional) output file name, if __false__ outputs to browser with required headers
+        @param Integer $pixelPerPoint (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $outerFrame (optional) code margin (silent zone) in 'virtual'  pixels
+        @param Integer $q (optional) JPEG compression level (__0__ .. __100__)
+        */
+        
         public static function jpg($frame, $filename = false, $pixelPerPoint = 8, $outerFrame = 4, $q = 85) 
         {
             $image = self::image($frame, $pixelPerPoint, $outerFrame);
@@ -974,7 +1138,14 @@
         }
     
         //----------------------------------------------------------------------
-        private static function image($frame, $pixelPerPoint = 4, $outerFrame = 4) 
+        /**
+        Creates generic GD2 image object
+        @param Array $frame frame containing code
+        @param Integer $pixelPerPoint (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $outerFrame (optional) code margin (silent zone) in 'virtual'  pixels
+        @return __Resource__ GD2 image resource (remember to ImageDestroy it!)
+        */
+        public static function image($frame, $pixelPerPoint = 4, $outerFrame = 4) 
         {
             $h = count($frame);
             $w = strlen($frame[0]);
@@ -1004,6 +1175,8 @@
             return $target_image;
         }
     }
+    
+    /** @} */
 
 
 
@@ -1021,7 +1194,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1038,8 +1211,11 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
-    define('STRUCTURE_HEADER_BITS',  20);
+	define('STRUCTURE_HEADER_BITS',  20);
     define('MAX_STRUCTURED_SYMBOLS', 16);
+	
+	/** @addtogroup CoreGroup */
+	/** @{ */
 
     class QRinputItem {
     
@@ -1738,8 +1914,7 @@
         }
     }
         
-        
-    
+	/** @}*/
 
 
 
@@ -1757,7 +1932,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -1773,18 +1948,38 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-     
+    
+	/** @addtogroup CoreGroup */
+	/** @{ */
+	
+    /**
+    PHP bit stream.
+    Class implementing array of bits (= 1 or 0 ints). Allows to initialize and append
+    bits from given Integer or array of Bytes.
+    */
     class QRbitstream {
     
+        /**
+        Array containing bit data stream 
+        */
         public $data = array();
         
         //----------------------------------------------------------------------
+        /** 
+        @return Integer size of byte stream
+        */
         public function size()
         {
             return count($this->data);
         }
         
         //----------------------------------------------------------------------
+        /** 
+        Allocates bit stream, fills bit data stream with 0's.
+        This operation is __destructive__, will replace orginal stream contents!
+        @param Integer $setLength desired target stream size
+        @return Integer 0 on success, other on failure
+        */
         public function allocate($setLength)
         {
             $this->data = array_fill(0, $setLength, 0);
@@ -1792,6 +1987,12 @@
         }
     
         //----------------------------------------------------------------------
+        /**
+        Creates new bit stream from given Integer number.
+        @param Integer $bits bit count 
+        @param Integer $num integer to convert
+        @return QRbitstream bit stream object containing first $bits bits from $num in order from LSB to MSB
+        */
         public static function newFromNum($bits, $num)
         {
             $bstream = new QRbitstream();
@@ -1811,6 +2012,12 @@
         }
         
         //----------------------------------------------------------------------
+        /**
+        Creates new bit stream from given byte array.
+        @param Integer $size size of array
+        @param Array $data array ob bytes
+        @return QRbitstream bit stream object containing bit contents of given bytes array
+        */
         public static function newFromBytes($size, $data)
         {
             $bstream = new QRbitstream();
@@ -1834,6 +2041,11 @@
         }
         
         //----------------------------------------------------------------------
+        /**
+        Appends given bit stream at end of this stream.
+        @param QRbitstream $arg bit stream to be appended
+        @return Integer status of append operation, 0 when success, -1 when $arg is null
+        */
         public function append(QRbitstream $arg)
         {
             if (is_null($arg)) {
@@ -1855,6 +2067,12 @@
         }
         
         //----------------------------------------------------------------------
+        /**
+        Appends bit stream cteated from given Integer number at end of current stream.
+        @param Integer $bits bit count 
+        @param Integer $num integer to convert
+        @return Integer status of append operation, status of append operation, 0 when success, -1 otherwise
+        */
         public function appendNum($bits, $num)
         {
             if ($bits == 0) 
@@ -1872,6 +2090,12 @@
         }
 
         //----------------------------------------------------------------------
+        /**
+        Appends bit stream created from from given byte array at end of current stream.
+        @param Integer $size size of array
+        @param Array $data array ob bytes
+        @return Integer status of append operation, status of append operation, 0 when success, -1 otherwise
+        */
         public function appendBytes($size, $data)
         {
             if ($size == 0) 
@@ -1889,6 +2113,10 @@
         }
         
         //----------------------------------------------------------------------
+        /** 
+        Converts current bit stream into byte array.
+        @returns Array array of bytes
+        */
         public function toByte()
         {
         
@@ -1928,6 +2156,7 @@
 
     }
 
+	/** @}*/
 
 
 
@@ -1945,7 +2174,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * The following data / specifications are taken from
  * "Two dimensional symbol -- QR-code -- Basic Specification" (JIS X0510:2004)
@@ -1967,6 +2196,11 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
+ 
+	/** @addtogroup CoreGroup */
+	/** @{ */
+	
+	/** Input stream splitter. */
     class QRsplit {
 
         public $dataStr = '';
@@ -2246,6 +2480,8 @@
             return $split->splitString();
         }
     }
+	
+	/** @} */
 
 
 
@@ -2266,7 +2502,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2283,22 +2519,40 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
+	/** @addtogroup CoreGroup */
+	/** @{ */
+	
+	/** Reed-Solomon encoder item */
     class QRrsItem {
     
-        public $mm;                  // Bits per symbol 
-        public $nn;                  // Symbols per block (= (1<<mm)-1) 
-        public $alpha_to = array();  // log lookup table 
-        public $index_of = array();  // Antilog lookup table 
-        public $genpoly = array();   // Generator polynomial 
-        public $nroots;              // Number of generator roots = number of parity symbols 
-        public $fcr;                 // First consecutive root, index form 
-        public $prim;                // Primitive element, index form 
-        public $iprim;               // prim-th root of 1, index form 
-        public $pad;                 // Padding bytes in shortened block 
-        public $gfpoly;
+        /** Bits per symbol */
+        public $mm;           
+		/** Symbols per block (= (1<<mm)-1) */
+        public $nn;      
+		/** Log lookup table */
+        public $alpha_to = array();
+		/** Antilog lookup table */
+        public $index_of = array();
+		/** Generator polynomial */
+        public $genpoly = array();
+		/** Number of generator roots = number of parity symbols */
+        public $nroots;              
+        /** First consecutive root, index form */
+		public $fcr;                 
+        /** Primitive element, index form */
+		public $prim;                
+        /** Prim-th root of 1, index form */
+		public $iprim;               
+        /** Padding bytes in shortened block */
+		public $pad;                 
+        /** Galois Field Polynomial */
+		public $gfpoly;              
     
         //----------------------------------------------------------------------
-        public function modnn($x)
+        /** Modulo function in defined Field
+		@param Integer $x number to be modulo-mapped
+		*/ 
+		public function modnn($x)
         {
             while ($x >= $this->nn) {
                 $x -= $this->nn;
@@ -2309,7 +2563,15 @@
         }
         
         //----------------------------------------------------------------------
-        public static function init_rs_char($symsize, $gfpoly, $fcr, $prim, $nroots, $pad)
+		/** Encoder initialisation
+			@param Integer $symsize symbol size, bit count (1..8)
+			@param Integer $gfpoly Galois Field Polynomial
+			@param Integer $fcr First consecutive root
+			@param Integer $prim Primitive element
+			@param Integer $nroots Number of generator roots = number of parity symbols
+			@param Integer $pad Padding bytes in shortened block
+		*/
+		public static function init_rs_char($symsize, $gfpoly, $fcr, $prim, $nroots, $pad)
         {
             // Common code for intializing a Reed-Solomon control block (char or int symbols)
             // Copyright 2004 Phil Karn, KA9Q
@@ -2395,6 +2657,10 @@
         }
         
         //----------------------------------------------------------------------
+		/** Appends char into encoder
+			@param String input
+			@param Array parity table
+		*/
         public function encode_rs_char($data, &$parity)
         {
             $MM       =& $this->mm;
@@ -2438,12 +2704,21 @@
     }
     
     //##########################################################################
-    
+    /** Reed-Solomon encoder */
     class QRrs {
     
+		/** Encoder items array */
         public static $items = array();
         
         //----------------------------------------------------------------------
+		/** Encoder initialisation
+			@param Integer $symsize symbol size, bit count (1..8)
+			@param Integer $gfpoly Galois Field Polynomial
+			@param Integer $fcr First consecutive root
+			@param Integer $prim Primitive element
+			@param Integer $nroots Number of generator roots = number of parity symbols
+			@param Integer $pad Padding bytes in shortened block
+		*/
         public static function init_rs($symsize, $gfpoly, $fcr, $prim, $nroots, $pad)
         {
             foreach(self::$items as $rs) {
@@ -2463,6 +2738,8 @@
             return $rs;
         }
     }
+	
+	/** @}*/
 
 
 
@@ -2480,7 +2757,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2497,11 +2774,16 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
+	
+	
 	define('N1', 3);
 	define('N2', 3);
 	define('N3', 40);
 	define('N4', 10);
 
+	/** @addtogroup CoreGroup */
+	/** @{ */
+	
 	class QRmask {
 	
 		public $runLength = array();
@@ -2643,7 +2925,7 @@
                     $b += (int)(ord($d[$y][$x]) & 1);
                 }
             }
-
+			
             return $b;
         }
         
@@ -2799,6 +3081,1146 @@
         //----------------------------------------------------------------------
     }
 
+	/** @}*/
+
+
+
+//---- qrarea.php -----------------------------
+
+
+
+
+/*
+ * PHP QR Code encoder
+ *
+ * Area finding for SVG and CANVAS output
+ *
+ * Based on libqrencode C library distributed under LGPL 2.1
+ * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
+ *
+ * PHP QR Code is distributed under LGPL 3
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+    //      N
+    //    W  E
+    //     S
+    
+    define('QR_AREA_N', 0);
+    define('QR_AREA_E', 1);
+    define('QR_AREA_S', 2);
+    define('QR_AREA_W', 3);
+    
+    define('QR_AREA_X', 0);
+    define('QR_AREA_Y', 1);
+    
+    define('QR_AREA_TRACKER', 0);
+    define('QR_AREA_PATH',    1);
+    define('QR_AREA_POINT',   2);
+    define('QR_AREA_RECT',    3);
+    define('QR_AREA_LSHAPE',  4);
+    
+    /** @addtogroup OutputGroup */
+    /** @{ */
+    
+    class QRareaGroup {
+        public $total = 0;
+        public $vertical = false;
+        public $horizontal = false;
+        public $points = array();
+        public $id = 0;
+        public $paths = array();
+        
+        //----------------------------------------------------------------------
+        public function __construct($selfId, $sx, $sy)
+        {
+            $this->total = 1;
+            $this->points = array(array($sx,$sy,false));
+            $this->id = $selfId;
+        }
+        
+    }
+
+    //##########################################################################
+    
+    class QRarea {
+    
+        public    $width = 0;
+        private   $tab = array();
+        private   $tab_edges = array();
+        private   $groups = array();
+        private   $curr_group = 0;
+        public    $paths = array();
+    
+    
+        //----------------------------------------------------------------------
+        public function __construct($source_tab) 
+        {
+            $py = 0;
+            $this->width = count($source_tab);
+            $this->tab = array();
+            $this->tab_edges = array();
+            $this->paths = array();
+    
+            foreach ($source_tab as $line) {
+                $arr = array();
+                $arr_edge = array();
+                $px=0;
+                
+                foreach (str_split($line) as $item) {
+                    
+                    if ($py<7 && $px<7)
+                        $item = 0;
+                        
+                    if ($py<7 && $px>=($this->width-7))
+                        $item = 0;
+                        
+                    if ($py>=($this->width-7) && $px<7)
+                        $item = 0;
+                                    
+                    $arr[] = (int)$item;
+                    $arr_edge[] = array(false, false, false, false);
+                    
+                    $px++;
+                }
+                
+                $this->tab[] = $arr;
+                $this->tab_edges[] = $arr_edge;
+                $py++;
+            }
+            
+            $this->paths[] = array(QR_AREA_TRACKER, 0,0);
+            $this->paths[] = array(QR_AREA_TRACKER, 0,($this->width-7));
+            $this->paths[] = array(QR_AREA_TRACKER, ($this->width-7),0);
+            
+            $this->groups = array();
+            $this->curr_group = 1;
+        }
+    
+        //----------------------------------------------------------------------
+        public function getGroups() 
+        {
+            return $this->groups;
+        }
+        
+        //----------------------------------------------------------------------
+        public function getPaths() 
+        {
+            return $this->paths;
+        }
+        
+        //----------------------------------------------------------------------
+        public function getWidth() 
+        {
+            return $this->width;
+        }
+        
+        //----------------------------------------------------------------------
+        public function dumpTab() 
+        {
+            echo "<style>";
+            echo "td { height: 2.5em;  color: black; font-size: 8px;
+            border-top: 1px solid silver; border-left: 1px solid silver }";
+            echo "table { border-bottom: 1px solid silver; border-right: 1px solid silver }";
+            echo "</style>";
+            echo "<table border=0 cellpadding=0 cellspacing=0>";
+            
+            $colorTab = array();
+            
+            foreach($this->tab as $line) {
+                foreach($line as $item) {
+                    if (!isset($colorTab[$item])) {
+                        $colorTab[$item] = 'hsl('.mt_rand(0, 360).', '.floor((mt_rand(0, 25))+75).'%, 50%)';
+                    }
+                }
+            }
+            
+            foreach($this->tab as $line) {
+                echo "<tr>";
+                foreach($line as $item) {
+                    if ($item == 0) {
+                        echo "<td>&nbsp;</td>";
+                    } else {
+                        echo "<td style='text-align:center;width: 4em;background:".$colorTab[$item]."'>".$item."</td>";
+                    }
+                }
+                echo "</tr>";
+            }
+            echo "</table>";
+        }
+        
+        //----------------------------------------------------------------------
+        public function dumpEdges() 
+        {
+            $style_off = '1px dotted silver;';
+            $style_on = '3px solid red;';
+            
+            $colorAlloc = array();
+            
+            echo "<table border='0'>";
+            $py = 0;
+            foreach($this->tab_edges as $line) {
+                $px = 0;
+                echo "<tr>";
+                foreach($line as $item) {
+                    
+                    $styles = 'border-top:';
+                    if ($item[QR_AREA_N])
+                            $styles .=  $style_on;
+                    else    $styles .=  $style_off;
+                    
+                    $styles .= 'border-bottom:';
+                    if ($item[QR_AREA_S])
+                            $styles .=  $style_on;
+                    else    $styles .=  $style_off;
+                    
+                    $styles .= 'border-right:';
+                    if ($item[QR_AREA_E])
+                            $styles .=  $style_on;
+                    else    $styles .=  $style_off;
+                    
+                    $styles .= 'border-left:';
+                    if ($item[QR_AREA_W])
+                            $styles .=  $style_on;
+                    else    $styles .=  $style_off;
+                    
+                    $color = '';
+                    $grp = $this->tab[$py][$px];
+                    
+                    if ($grp>0) {
+                        if (!isset($colorAlloc[$grp])) {
+                            $colorAlloc[$grp] = 'hsl('.mt_rand(0, 360).', '.floor((mt_rand(0, 25))+75).'%, 50%)';
+                        }
+                
+                        $color = 'background:'.$colorAlloc[$grp];
+                    }
+                    
+                    if ($grp == 0)
+                        $grp = '&nbsp;';
+                    
+                    echo "<td style='text-align:center;width:1.5em;".$styles.$color."'>".$grp."</td>";
+                    $px++;
+                }
+                echo "</tr>";
+                $py++;
+            }
+            echo "</table>";
+        }
+        
+        //----------------------------------------------------------------------
+        private static function rle(&$stringData)
+        {
+            $outArray = array();
+            $symbolArray = str_split($stringData);
+            $last = '';
+            $run = 1;
+            
+            while (count($symbolArray) > 0) {
+                $symbol = array_shift($symbolArray);
+                
+                if ($symbol != $last) {
+                    if ($run > 1) 
+                        $outArray[] = $run;
+                    
+                    if ($last != '')
+                        $outArray[] = $last;
+                        
+                    $run = 1;
+                    $last = $symbol;
+                } else {
+                    $run++;
+                }
+            }
+            
+            if ($run > 1) 
+                $outArray[] = $run;
+                
+            $outArray[] = $last;
+            
+            $stringData = $outArray;
+        }
+        
+    
+        //----------------------------------------------------------------------
+        private function getAt($posx, $posy)
+        {
+            if (($posx<0)||($posy<0)||($posx>=$this->width)||($posy>=$this->width))
+                return 0;           
+                
+            return $this->tab[$posy][$posx];            
+        }
+        
+        //----------------------------------------------------------------------
+        private function getOnElem($elem, $deltax = 0, $deltay = 0)
+        {
+            $posx = $elem[0]+$deltax;
+            $posy = $elem[1]+$deltay;
+            
+            if (($posx<0)||($posy<0)||($posx>=$this->width)||($posy>=$this->width))
+                return 0;           
+                
+            return $this->tab[$posy][$posx];            
+        }
+        
+        //----------------------------------------------------------------------
+        private function addGroupElement($groupId, $h, $v, $sx, $sy)
+        {
+            $this->groups[$groupId]->total++;
+            if ($h)
+                $this->groups[$groupId]->horizontal = true;
+            if ($v)
+                $this->groups[$groupId]->vertical = true;                
+            $this->groups[$groupId]->points[] = array($sx, $sy, false);
+        }
+        
+        //----------------------------------------------------------------------
+        public function detectGroups()
+        {
+            for ($sy = 0; $sy < $this->width; $sy++) {
+                for ($sx = 0; $sx < $this->width; $sx++) {
+                
+                    if ($this->tab[$sy][$sx] == 1) { // non-allocated
+                    
+                        $gid_left = 0;
+                        $gid_top = 0;
+                    
+                        $grouped = false;
+                        
+                        if ($sx>0) {
+                            
+                            $gid_left = $this->tab[$sy][$sx-1]; // previous on left
+                            
+                            if ($gid_left > 1) { // if already in group
+                                $this->tab[$sy][$sx] = $gid_left;
+                                $grouped = true;
+                                $this->addGroupElement($gid_left, true, false, $sx, $sy);
+                            }  
+                        }
+                        
+                        if ($sy > 0) {
+                        
+                            $gid_top = $this->tab[$sy-1][$sx]; // previous on top
+                            
+                            if ($gid_top > 1) { //if in group
+                                if (!$grouped) { // and not grouped
+                                
+                                    $this->tab[$sy][$sx] = $gid_top;
+                                    $grouped = true;
+                                    
+                                    $this->addGroupElement($gid_top, false, true, $sx, $sy);
+                                    
+                                } else if($gid_top != $gid_left) { // was in left group
+                                
+                                    $grouped = true;
+                                    
+                                    $this->groups[$gid_top]->vertical = true;
+                                    $this->groups[$gid_top]->horizontal = true;
+                                    
+                                    $this->groups[$gid_top]->total = $this->groups[$gid_top]->total + $this->groups[$gid_left]->total;
+                                    
+                                    foreach($this->groups[$gid_left]->points as $elem)
+                                        $this->tab[$elem[1]][$elem[0]] = $gid_top;
+                                    
+                                    $this->groups[$gid_top]->points = array_values(array_merge($this->groups[$gid_top]->points, $this->groups[$gid_left]->points));
+                                    unset($this->groups[$gid_left]);
+                                    
+                                    //refarb group
+                                }
+                            }
+                        }
+                        
+                        if (!$grouped) {
+                            $this->curr_group++;
+                            $this->tab[$sy][$sx] = $this->curr_group;
+                            $this->groups[$this->curr_group] = new QRareaGroup($this->curr_group, $sx, $sy);
+                        }
+                        
+                    }
+                }
+            }
+        }
+        
+        //----------------------------------------------------------------------
+        private function detectSquare($group)
+        {
+            $max_x = 0;
+            $max_y = 0;
+            $min_x = $this->width;
+            $min_y = $this->width;
+            
+            foreach($group->points as $elem) {
+                $min_x = min($min_x, $elem[QR_AREA_X]);
+                $max_x = max($max_x, $elem[QR_AREA_X]);
+                $min_y = min($min_y, $elem[QR_AREA_Y]);
+                $max_y = max($max_y, $elem[QR_AREA_Y]);
+            }
+            
+            return array($min_x, $min_y, $max_x+1, $max_y+1);
+        }
+        
+        //----------------------------------------------------------------------
+        public function detectAreas()
+        {
+            $squares = array();
+            $points = array();
+            $lshapes = array();
+            
+            foreach ($this->groups as $groupId=>&$group) {
+                if ($group->total > 3) {
+                
+                    if ((!$group->vertical)||(!$group->horizontal)) {
+                    
+                        $squareCoord = $this->detectSquare($group);
+                        array_unshift($squareCoord, QR_AREA_RECT);
+                        
+                        $this->paths[] = $squareCoord;
+                    
+                    } else {
+                
+                        $this->detectPaths($group);
+                        unset($group->points);
+                        
+                        foreach($group->paths as &$path)
+                            self::rle($path[2]);
+                        
+                        $this->paths[] = array(QR_AREA_PATH, $group->paths);
+                    }
+                } else if (($group->total == 3)&&($group->vertical)&&($group->horizontal)) {
+                    $squareCoord = $this->detectSquare($group);
+                    $variant = 0;
+                    
+                    if ($this->getOnElem($squareCoord, 0, 0) != $group->id)
+                        $variant = 0;
+                        
+                    if ($this->getOnElem($squareCoord, 1, 0) != $group->id)
+                        $variant = 1;
+                        
+                    if ($this->getOnElem($squareCoord, 0, 1) != $group->id)
+                        $variant = 2;
+                        
+                    if ($this->getOnElem($squareCoord, 1, 1) != $group->id)
+                        $variant = 3;
+                        
+                    $lshapes[] = $squareCoord[QR_AREA_X];
+                    $lshapes[] = $squareCoord[QR_AREA_Y];
+                    $lshapes[] = $variant;
+                    
+                } else if ($group->total >= 2) {
+                    $squareCoord = $this->detectSquare($group);
+                    $squares = array_merge($squares, $squareCoord);
+                } else if ($group->total == 1) {
+                    $points[] = $group->points[0][0];
+                    $points[] = $group->points[0][1];
+                }
+            }
+            
+            if (count($points) > 0) {
+                array_unshift($points, QR_AREA_POINT);
+                $this->paths[] = $points;
+            }
+            
+            if (count($squares) > 0) {
+                array_unshift($squares, QR_AREA_RECT);
+                $this->paths[] = $squares;
+            }
+            
+            if (count($lshapes) > 0) {
+                array_unshift($lshapes, QR_AREA_LSHAPE);
+                $this->paths[] = $lshapes;
+            }
+        }
+        
+        //----------------------------------------------------------------------
+        private function reserveEdgeOnElem($elem, $edgeNo)
+        {
+            $this->tab_edges[$elem[QR_AREA_Y]][$elem[QR_AREA_X]][$edgeNo] = true;
+        }
+        
+        //----------------------------------------------------------------------
+        private function reserveEdge($px, $py, $edgeNo)
+        {
+            $this->tab_edges[$py][$px][$edgeNo] = true;
+        }
+        
+         //----------------------------------------------------------------------
+        private function markAdjacentEdges($group)
+        {
+            foreach($group->points as $elem) {
+                if ($this->getOnElem($elem, -1, 0) == $group->id)
+                    $this->reserveEdgeOnElem($elem, QR_AREA_W);
+                    
+                if ($this->getOnElem($elem, +1, 0) == $group->id)
+                    $this->reserveEdgeOnElem($elem, QR_AREA_E);
+                    
+                if ($this->getOnElem($elem, 0, -1) == $group->id)
+                    $this->reserveEdgeOnElem($elem, QR_AREA_N);
+                
+                if ($this->getOnElem($elem, 0, +1) == $group->id)
+                    $this->reserveEdgeOnElem($elem, QR_AREA_S);
+            }
+        }
+        
+        //----------------------------------------------------------------------
+        private function detectPaths(&$group)
+        {
+            $this->markAdjacentEdges($group);
+            
+            $elem = $group->points[0];
+            $waylist = $this->findPath($group, $elem[QR_AREA_X], $elem[QR_AREA_Y]);
+            $group->paths[] = array($elem[QR_AREA_X], $elem[QR_AREA_Y], $waylist);
+            
+            $tab = array();
+            foreach($group->points as $elem) {
+                
+                $edgeTab = $this->tab_edges[$elem[QR_AREA_Y]][$elem[QR_AREA_X]];
+                
+                if (!(  $edgeTab[QR_AREA_N] 
+                    &&  $edgeTab[QR_AREA_E] 
+                    &&  $edgeTab[QR_AREA_S] 
+                    &&  $edgeTab[QR_AREA_W])) {
+                    
+                    if (!$edgeTab[QR_AREA_S]) {
+                       
+                        $waylistw = $this->findPath($group, $elem[QR_AREA_X], $elem[QR_AREA_Y]+1);
+                        $group->paths[] = array($elem[QR_AREA_X], $elem[QR_AREA_Y]+1, $waylistw);
+                    }
+                }
+            }
+  
+        }
+        
+        //----------------------------------------------------------------------
+        private function findPath($group, $sx, $sy)
+        {
+            $px = $sx;
+            $py = $sy;
+        
+            $waylist = '';
+            $dir = '';
+            $lastdir = '';
+            
+            $moves = array(
+            // magic :)
+                0=>'',  1=>'L', 2=>'T', 3=>'L', 4=>'B', 5=>'B', 6=>'B,T', 7=>'B'
+                ,8=>'R', 9=>'R,L', 10=>'T', 11=>'L',12=>'R',13=>'R',14=>'T',15=>''
+            );
+            
+            do
+            {
+                $Q  = ($this->getAt($px-1, $py-1) == $group->id)?1:0;
+                $Q += ($this->getAt($px, $py-1)   == $group->id)?2:0;
+                $Q += ($this->getAt($px-1, $py)   == $group->id)?4:0;
+                $Q += ($this->getAt($px, $py)     == $group->id)?8:0;
+                
+                if ($moves[$Q] == '') 
+                    throw new Exception('It should NEVER happened!');
+                    
+                $move_expl = explode(',', $moves[$Q]);
+                $have_way = false;
+                
+                $dir = '';
+                
+                while ((count($move_expl) > 0)&&($have_way == false)) {
+                    $way = array_shift($move_expl);
+                    
+                    if (($have_way==false)&&($way=='R')&&($this->tab_edges[$py][$px][QR_AREA_N]==false)) {
+                        $have_way = true;
+                        $dir = $way;
+                        $this->reserveEdge($px, $py, QR_AREA_N);
+                        $px++;                      
+                    } 
+                    
+                    if (($have_way==false)&&($way=='B')&&($this->tab_edges[$py][$px-1][QR_AREA_E]==false)) {
+                        $have_way = true;
+                        $dir = $way;
+                        $this->reserveEdge($px-1, $py, QR_AREA_E);
+                        $py++;                      
+                    } 
+                    
+                    if (($have_way==false)&&($way=='L')&&($this->tab_edges[$py-1][$px-1][QR_AREA_S]==false)) {
+                        $have_way = true;
+                        $dir = $way;
+                        $this->reserveEdge($px-1, $py-1, QR_AREA_S);
+                        $px--;                      
+                    } 
+                    
+                    if (($have_way==false)&&($way=='T')&&($this->tab_edges[$py-1][$px][QR_AREA_W]==false)) {
+                        $have_way = true;
+                        $dir = $way;
+                        $this->reserveEdge($px, $py-1, QR_AREA_W);
+                        $py--;                      
+                    } 
+                }
+
+                $waylist .= $dir;
+            
+            } while (!(($px==$sx)&&($py==$sy)));
+            
+            return $waylist;
+        }
+    }
+    
+    /** @} */
+
+
+
+//---- qrcanvas.php -----------------------------
+
+
+
+
+/*
+ * PHP QR Code encoder
+ *
+ * CANVAS output
+ *
+ * Based on libqrencode C library distributed under LGPL 2.1
+ * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
+ *
+ * PHP QR Code is distributed under LGPL 3
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+ 
+    /** @addtogroup OutputGroup */
+    /** @{ */
+    
+    class QRcanvasOutput extends QRarea {
+ 
+        public function __construct($source_tab) 
+        {
+            parent::__construct($source_tab);
+        }
+ 
+        //----------------------------------------------------------------------
+        public static function encodeNum($num)
+        {
+            $addTab = array(0=>'', 1=>'z', 2=>'Z', 3=>'+');
+            $map = '0123456789abcdefghijklmnopqrstuvwxyABCDEFGHIJKLMNOPQRSTUVWXY';
+            $mapPos = $num % 60;
+            $mapAdd = (int)($num / 60);
+            
+            return $addTab[$mapAdd].$map[$mapPos];
+        }
+        
+        //----------------------------------------------------------------------
+        public static function compact_path(&$pathTab) 
+        {
+            if (count($pathTab) == 0) {
+                $pathTab = '';
+            } else {
+                $pathTab = count($pathTab).','.join(',', $pathTab);
+            }
+        }
+        
+        //----------------------------------------------------------------------
+        public static function compact_points(&$pointsTab) 
+        {
+            if (count($pointsTab) == 0) {
+                $pointsTab = '';
+            } else {
+                $compacted = '';
+                foreach ($pointsTab as $point)
+                    $compacted .= self::encodeNum($point);
+                $pointsTab = $compacted;
+            }
+        }
+        
+        //----------------------------------------------------------------------
+        public static function compactCanvasCommands($ops)
+        {
+            $accumulated  = array();
+            
+            $accumulated['SR'] = array();
+            $accumulated['WR'] = array();
+            $accumulated['SP'] = array();
+            $accumulated['WP'] = array();
+            $accumulated['SB'] = array();
+            $accumulated['WB'] = array();
+            $accumulated['SO'] = array();
+            
+            while (count($ops) > 0) {
+                $color  = array_shift($ops);
+                $opcode = array_shift($ops);
+                
+                if (($opcode == 'R') || ($opcode == 'P')) {
+                
+                    do {
+                        $num = array_shift($ops);
+                        if (is_int($num)) {
+                            $accumulated[$color.$opcode][] = $num;
+                        } else {
+                            array_unshift($ops, $num);
+                        }
+                        
+                    } while ((count($ops) > 0)&&(is_int($num)));
+
+                    
+                } else if ($opcode == 'B') {
+                    
+                    array_shift($ops);
+                    
+                    $px  = array_shift($ops);
+                    $py  = array_shift($ops);
+                    
+                    array_shift($ops);
+                    
+                    $conftab = array();
+                    $num = array_shift($ops);
+                    
+                    while ((count($ops) > 0)&&(!($num === 'E'))) {
+                        $conftab[] = $num;
+                        $num = array_shift($ops);
+                    }
+                    
+                    $cc = count($conftab);
+                    $deltas = '';
+                    
+                    $lastposx = $px;
+                    $lastposy = $py;
+                    
+                    for($pos=0;$pos <$cc; $pos+=2) {
+                    
+                        $dx = $lastposx - $conftab[$pos];
+                        $dy = $lastposy - $conftab[$pos+1];
+                    
+                        $lastposx = $conftab[$pos];
+                        $lastposy = $conftab[$pos+1];
+                    
+                        if ($dx < 0) {
+                            $deltas .= chr(ord('a')-1-$dx);
+                        } else if ($dx > 0) {
+                            $deltas .= chr(ord('A')-1+$dx);
+                        } else {
+                            $deltas .= '0';
+                        }
+                        
+                        if ($dy < 0) {
+                            $deltas .= chr(ord('a')-1-$dy);
+                        } else if ($dy > 0) {
+                            $deltas .= chr(ord('A')-1+$dy);
+                        } else {
+                            $deltas .= '0';
+                        }
+                    
+                    }
+                    
+                    $deltas = strtr($deltas, array(
+                        '00'=>'1',
+                        'aa'=>'2',
+                        'aA'=>'3',
+                        'Aa'=>'4',
+                        'AA'=>'5',
+                        'aB'=>'6',
+                        'Ab'=>'7',
+                        'bA'=>'8',
+                        'Ba'=>'9'
+                    ));
+                    
+                    $accumulated[$color.$opcode][] = join(',', array($px, $py, $deltas));
+                } else if ($opcode == 'O') {
+                    $px  = array_shift($ops);
+                    $py  = array_shift($ops);
+                    
+                    $accumulated[$color.$opcode][] = join(',', array($px, $py));
+                }
+            }
+            
+            self::compact_points($accumulated['SR']);
+            self::compact_points($accumulated['WR']);
+            self::compact_points($accumulated['SP']);
+            self::compact_points($accumulated['WP']);
+            
+            self::compact_path($accumulated['SB']);
+            self::compact_path($accumulated['WB']);
+            
+            if (count($accumulated['SO']) > 0)
+                    $accumulated['SO'] = join(',',$accumulated['SO']);
+            else    $accumulated['SO'] = '';
+            
+            $mapping = array(
+                'SO'=>'O',
+                'SB'=>'B',
+                'WB'=>'b',
+                'SR'=>'R',
+                'WR'=>'r',
+                'SP'=>'P',
+                'WP'=>'p'
+            );
+            
+            $whole = array();
+            
+            foreach($mapping as $key=>$symb) {
+                if ($accumulated[$key]!='')
+                    $whole[] = $symb.','.$accumulated[$key];
+            }
+            
+            return join(',', $whole);
+        }
+        
+
+        //----------------------------------------------------------------------
+        public function getCanvasOps()
+        {
+            $ops = array();
+            
+            foreach ($this->paths as $path) {
+                switch ($path[0]) {
+                    case QR_AREA_PATH:
+                            $pNum = 0;
+                            
+                            foreach($path[1] as $pathDetails) {
+                                if ($pNum == 0) {
+                                    $ops[] = 'S';
+                                } else if ($pNum > 0) {
+                                    $ops[] = 'W';
+                                }
+                                
+                                $ops[] = 'B';
+                                
+                                $px = array_shift($pathDetails);
+                                $py = array_shift($pathDetails);
+                                
+                                $ops[] = 'M';
+                                $ops[] = $px;
+                                $ops[] = $py;
+                                
+                                $rle_steps = array_shift($pathDetails);
+                                
+                                $lastOp = '';
+                                
+                                while(count($rle_steps) > 0) {
+                                
+                                    $delta = 1;
+                                    
+                                    $operator = array_shift($rle_steps);
+                                    if (($operator != 'R') && ($operator != 'L') && ($operator != 'T') && ($operator != 'B')) {
+                                        $delta = (int)$operator;
+                                        $operator = array_shift($rle_steps);
+                                    }
+                                    
+                                    if ($operator == 'R') $px += $delta;
+                                    if ($operator == 'L') $px -= $delta;
+                                    if ($operator == 'T') $py -= $delta;
+                                    if ($operator == 'B') $py += $delta;
+                                    
+                                    if ($lastOp != 'T')
+                                        $ops[] = 'T';
+                                        
+                                    $ops[] = $px;
+                                    $ops[] = $py;
+                                    
+                                    $lastOp = 'T';
+                                }
+                                
+                                $ops[] = 'E';
+                                
+                                $pNum++;
+                            }
+    
+                        break;
+                    case QR_AREA_POINT:
+                                
+                                $symb = array_shift($path);
+                                
+                                $ops[] = 'S';
+                                
+                                $lastOp = '';
+                                
+                                while(count($path) > 0) {
+                                    $px = array_shift($path);
+                                    $py = array_shift($path);
+                                    
+                                    if ($lastOp != 'P')
+                                        $ops[] = 'P';
+                                        
+                                    $ops[] = $px;
+                                    $ops[] = $py;
+                                    
+                                    $lastOp = 'P';
+                                }
+                                
+                        break;
+                        
+                    case QR_AREA_RECT:
+                                
+                                $symb = array_shift($path);
+                                
+                                $ops[] = 'S';
+                                
+                                $lastOp = '';
+                                
+                                while(count($path) > 0) {
+                                    $px = array_shift($path);
+                                    $py = array_shift($path);
+                                    $ex = array_shift($path);
+                                    $ey = array_shift($path);
+                                    
+                                    if ($lastOp != 'R')
+                                        $ops[] = 'R';
+                                        
+                                    $ops[] = $px;
+                                    $ops[] = $py;
+                                    $ops[] = $ex-$px;
+                                    $ops[] = $ey-$py;
+                                    
+                                    $lastOp = 'R';
+                                }
+                                
+                        break;                      
+                        
+                    case QR_AREA_LSHAPE:
+                                
+                                $symb = array_shift($path);
+                                
+                                while(count($path) > 0) {
+                                    $px = array_shift($path);
+                                    $py = array_shift($path);
+                                    $mode = (int)array_shift($path);
+                                    
+                                    $pxd = ($mode % 2)?1:0;
+                                    $pyd = ($mode > 1)?1:0;
+                                    
+                                    $ops[] = 'S';
+                                    $ops[] = 'R';
+                                    $ops[] = $px;
+                                    $ops[] = $py;
+                                    $ops[] = 2;
+                                    $ops[] = 2;
+                                    
+                                    $ops[] = 'W';
+                                    $ops[] = 'P';
+                                    $ops[] = $px+$pxd;
+                                    $ops[] = $py+$pyd;
+                                }
+                                
+                        break;  
+                        
+                    case QR_AREA_TRACKER:
+                                
+                                $symb = array_shift($path);
+                                
+                                $px = array_shift($path);
+                                $py = array_shift($path);
+                                    
+                                $ops[] = 'S';
+                                $ops[] = 'O';
+                                $ops[] = $px;
+                                $ops[] = $py;
+                                    
+                        break;  
+                }
+            }
+            
+            return self::compactCanvasCommands($ops);
+        }
+    }
+    
+    /** @} */
+ 
+
+
+
+//---- qrsvg.php -----------------------------
+
+
+
+
+/*
+ * PHP QR Code encoder
+ *
+ * SVG output support
+ *
+ * Based on libqrencode C library distributed under LGPL 2.1
+ * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
+ *
+ * PHP QR Code is distributed under LGPL 3
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+ 
+	/** @addtogroup OutputGroup */
+	/** @{ */
+	
+	class QRsvgOutput extends QRarea {
+ 
+		public function __construct($source_tab) 
+		{
+			parent::__construct($source_tab);
+		}
+
+		//----------------------------------------------------------------------
+        public function mapX($px)
+		{	
+			return $px;
+		}
+
+		//----------------------------------------------------------------------
+        public function mapY($py)
+		{
+			return $py;
+		}
+
+		//----------------------------------------------------------------------
+        public function getRawSvg()
+		{
+			$lib = array();
+			$svg = array();
+			
+			$aggregate_paths = array();
+			
+			foreach ($this->paths as $path) {
+				switch ($path[0]) {
+					case QR_AREA_PATH:
+							$pNum = 0;
+							
+							foreach($path[1] as $pathDetails) {
+								
+								$px = array_shift($pathDetails);
+								$py = array_shift($pathDetails);
+								$rle_steps = array_shift($pathDetails);
+								
+								$aggregate_add = 'M'.$px.','.$py.' ';
+								
+								while(count($rle_steps) > 0) {
+								
+									$delta = 1;
+									
+									$operator = array_shift($rle_steps);
+									if (($operator != 'R') && ($operator != 'L') && ($operator != 'T') && ($operator != 'B')) {
+										$delta = (int)$operator;
+										$operator = array_shift($rle_steps);
+									}
+									
+									if ($operator == 'R') $aggregate_add .= 'h'.$delta;
+									if ($operator == 'L') $aggregate_add .= 'h-'.$delta;
+									if ($operator == 'T') $aggregate_add .= 'v-'.$delta;
+									if ($operator == 'B') $aggregate_add .= 'v'.$delta;
+								}
+								
+								$aggregate_paths[] = $aggregate_add;
+								
+								$pNum++;
+							}
+	
+						break;
+					case QR_AREA_POINT:
+								
+							$symb = array_shift($path);
+							
+							while(count($path) > 0) {
+								$px = array_shift($path);
+								$py = array_shift($path);
+								
+								$aggregate_paths[] = 'M'.$px.','.$py.' v1h1v-1h-1';
+							}
+							
+						break;
+						
+					case QR_AREA_RECT:
+							
+							$symb = array_shift($path);
+							
+							while(count($path) > 0) {
+								$px = array_shift($path);
+								$py = array_shift($path);
+								$ex = array_shift($path);
+								$ey = array_shift($path);
+								
+								$w = $ex-$px;
+								$h = $ey-$py;
+								
+								$aggregate_paths[] = 'M'.$px.','.$py.' h'.$w.'v'.$h.'h-'.$w.'v-'.$h;
+							}
+							
+						break;						
+						
+					case QR_AREA_LSHAPE:
+								
+							$symb = array_shift($path);
+							
+							$l_shapes[0] = 'm1,0h1v2h-2v-1h1z';
+							$l_shapes[1] = 'h1v1h1v1h-2z';
+							$l_shapes[2] = 'h2v2h-1v-1h-1z';
+							$l_shapes[3] = 'h2v1h-1v1h-1z';
+							
+							while(count($path) > 0) {
+								$px = array_shift($path);
+								$py = array_shift($path);
+								$mode = (int)array_shift($path);
+								
+								$aggregate_paths[] =  'M'.$px.','.$py.' '.$l_shapes[$mode];
+							}
+								
+						break;	
+						
+					case QR_AREA_TRACKER:
+								
+							if (!isset($lib['tracker'])) {
+								$lib['tracker'] = '<symbol id="tracker"><path d="m 0 7 0 7 7 0 0 -7 -7 0 z m 1 1 5 0 0 5 -5 0 0 -5 z m 1 1 0 3 3 0 0 -3 -3 0 z" style="fill:#000000;stroke:none"></path></symbol>';
+							}
+							
+							$symb = array_shift($path);
+							
+							$px = array_shift($path);
+							$py = array_shift($path);
+								
+							$svg[] = '<use x="'.$px.'" y="'.($py-7).'" xlink:href="#tracker"></use>';
+									
+						break;	
+				}
+			}
+			
+			$svg[] = '<path d="'.join(' ', $aggregate_paths).'" style="fill:#000000;stroke:none" ></path>';
+							
+
+			
+			return join("\n", $lib)."\n".join("\n", $svg);
+		}
+	}
+ 
+	/** @} */
+	
 
 
 
@@ -2816,7 +4238,7 @@
  * Copyright (C) 2006, 2007, 2008, 2009 Kentaro Fukuchi <fukuchi@megaui.net>
  *
  * PHP QR Code is distributed under LGPL 3
- * Copyright (C) 2010 Dominik Dzienia <deltalab at poczta dot fm>
+ * Copyright (C) 2010-2013 Dominik Dzienia <deltalab at poczta dot fm>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2833,12 +4255,29 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
  
+    /** @defgroup CoreGroup Standard API Core 
+    Core encoder classes */
+     
+    /** @addtogroup CoreGroup */
+    /** @{ */
+     
+    //##########################################################################
+    /** 
+    Data block with raw data and it's Error Correction Code data.
+    */
     class QRrsblock {
         public $dataLength;
         public $data = array();
         public $eccLength;
         public $ecc = array();
         
+        /** Data block Constructor
+        @param Integer $dl length of data stream
+        @param Array $data data stream
+        @param Integer $el ECC length
+        @param Array $el ECC stream (modified, by reference)
+        @param QRrsItem $rs RS encoding item
+        */
         public function __construct($dl, $data, $el, &$ecc, QRrsItem $rs)
         {
             $rs->encode_rs_char($data, $ecc);
@@ -2851,19 +4290,25 @@
     };
     
     //##########################################################################
-
+    /** Raw Code holder.
+    Contains encoded code data before there are spatialy distributed into frame and masked.
+    Here goes dividing data into blocks and calculating ECC stream. */
     class QRrawcode {
-        public $version;
-        public $datacode = array();
-        public $ecccode = array();
-        public $blocks;
-        public $rsblocks = array(); //of RSblock
-        public $count;
-        public $dataLength;
-        public $eccLength;
-        public $b1;
+    
+        public $version;                ///< __Integer__ code Version
+        public $datacode = array();     ///< __Array__ data stream
+        public $ecccode = array();      ///< __Array__ ECC Stream
+        public $blocks;                 ///< __Integer__ RS Blocks count
+        public $rsblocks = array();     ///< __Array__ of RSblock, ECC code blocks
+        public $count;                  ///< __Integer__ position of currently processed ECC code
+        public $dataLength;             ///< __Integer__ data stream length
+        public $eccLength;              ///< __Integer__ ECC stream length
+        public $b1;                     ///< __Integer__ width of code in pixels, used as a modulo base for column overflow
         
         //----------------------------------------------------------------------
+        /** Raw Code holder Constructor 
+        @param QRinput $input input stream
+        */
         public function __construct(QRinput $input)
         {
             $spec = array(0,0,0,0,0);
@@ -2892,6 +4337,9 @@
         }
         
         //----------------------------------------------------------------------
+        /** Initializes Raw Code according to current code speciffication
+        @param Array $spec code speciffigation, as provided by QRspec
+        */
         public function init(array $spec)
         {
             $dl = QRspec::rsDataCodes1($spec);
@@ -2935,6 +4383,9 @@
         }
         
         //----------------------------------------------------------------------
+        /** Gets ECC code 
+        @return Integer ECC byte for current object position
+        */
         public function getCode()
         {
             $ret;
@@ -2960,14 +4411,45 @@
     }
 
     //##########################################################################
+    /** 
+    __Main class to create QR-code__.
+    QR Code symbol is a 2D barcode that can be scanned by handy terminals such as a mobile phone with CCD.
+    The capacity of QR Code is up to 7000 digits or 4000 characters, and has high robustness.
+    This class supports QR Code model 2, described in JIS (Japanese Industrial Standards) X0510:2004 or ISO/IEC 18004.
     
+    Currently the following features are not supported: ECI and FNC1 mode, Micro QR Code, QR Code model 1, Structured mode.
+    
+    @abstract Class for generating QR-code images, SVG and HTML5 Canvas 
+    @author Dominik Dzienia
+    @copyright 2010-2013 Dominik Dzienia and others
+    @link http://phpqrcode.sourceforge.net
+    @license http://www.gnu.org/copyleft/lesser.html LGPL
+    */
+
     class QRcode {
     
-        public $version;
-        public $width;
-        public $data; 
+        public $version;    ///< __Integer__ QR code version. Size of QRcode is defined as version. Version is from 1 to 40. Version 1 is 21*21 matrix. And 4 modules increases whenever 1 version increases. So version 40 is 177*177 matrix.
+        public $width;      ///< __Integer__ Width of code table. Because code is square shaped - same as height.
+        public $data;       ///< __Array__ Ready, masked code data.
+        
+        /** Canvas JS include flag.
+        If canvas js support library was included, we remember it static in QRcode. 
+        (because file should be included only once)
+         */
+        public static $jscanvasincluded = false;
         
         //----------------------------------------------------------------------
+        /**
+        Encode mask
+        Main function responsible for creating code. 
+        We get empty frame, then fill it with data from input, then select best mask and apply it.
+        If $mask argument is greater than -1 we assume that user want's that specific mask number (ranging form 0-7) to be used.
+        Otherwise (when $mask is -1) mask is detected using algorithm depending of global configuration,
+        
+        @param QRinput $input data object
+        @param Integer $mask sugested masking mode
+        @return QRcode $this (current instance)
+        */
         public function encodeMask(QRinput $input, $mask)
         {
             if($input->getVersion() < 0 || $input->getVersion() > QRSPEC_VERSION_MAX) {
@@ -2985,7 +4467,7 @@
             $width = QRspec::getWidth($version);
             $frame = QRspec::newFrame($version);
             
-            $filler = new FrameFiller($width, $frame);
+            $filler = new QRframeFiller($width, $frame);
             if(is_null($filler)) {
                 return NULL;
             }
@@ -3035,23 +4517,37 @@
             
             QRtools::markTime('after_mask');
             
-            $this->version = $version;
-            $this->width = $width;
-            $this->data = $masked;
+            $this->version  = $version;
+            $this->width    = $width;
+            $this->data     = $masked;
             
             return $this;
         }
     
         //----------------------------------------------------------------------
+        /**
+        Encode input with mask detection.
+        Shorthand for encodeMask, without specifing particular, static mask number.
+        
+        @param QRinput $input data object to be encoded
+        @return 
+        */
         public function encodeInput(QRinput $input)
         {
             return $this->encodeMask($input, -1);
         }
         
         //----------------------------------------------------------------------
+        /**
+        Encode string, forcing 8-bit encoding
+        @param String $string input string
+        @param Integer $version code version (size of code area)
+        @param Integer $level ECC level (see: Global Constants -> Levels of Error Correction)
+        @return QRcode $this (current instance)
+        */
         public function encodeString8bit($string, $version, $level)
         {
-            if(string == NULL) {
+            if($string == NULL) {
                 throw new Exception('empty string!');
                 return NULL;
             }
@@ -3059,7 +4555,7 @@
             $input = new QRinput($version, $level);
             if($input == NULL) return NULL;
 
-            $ret = $input->append($input, QR_MODE_8, strlen($string), str_split($string));
+            $ret = $input->append(QR_MODE_8, strlen($string), str_split($string));
             if($ret < 0) {
                 unset($input);
                 return NULL;
@@ -3068,6 +4564,21 @@
         }
 
         //----------------------------------------------------------------------
+        /**
+        Encode string, using optimal encodings.
+        Encode string dynamically adjusting encoding for subsections of string to
+        minimize resulting code size. For complex string it will split string into
+        subsections: Numerical, Alphanumerical or 8-bit.
+        @param String $string input string
+        @param Integer $version code version (size of code area)
+        @param String $level ECC level (see: Global Constants -> Levels of Error Correction)
+        @param Integer $hint __QR_MODE_8__ or __QR_MODE_KANJI__, Because Kanji encoding
+        is kind of 8 bit encoding we need to hint encoder to use Kanji mode explicite.
+        (otherwise it may try to encode it as plain 8 bit stream)
+        @param Boolean $casesensitive hint if given string is case-sensitive, because
+        if not - encoder may use optimal QR_MODE_AN instead of QR_MODE_8
+        @return QRcode $this (current instance)
+        */
         public function encodeString($string, $version, $level, $hint, $casesensitive)
         {
 
@@ -3087,7 +4598,18 @@
             return $this->encodeInput($input);
         }
         
-        //----------------------------------------------------------------------
+        //######################################################################
+        /**
+        Creates PNG image containing QR-Code.
+        Simple helper function to create QR-Code Png image with one static call.
+        @param String $text text string to encode 
+        @param String $outfile (optional) output file name, if __false__ outputs to browser with required headers
+        @param Integer $level (optional) error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $size (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $margin (optional) code margin (silent zone) in 'virtual'  pixels
+        @param Boolean $saveandprint (optional) if __true__ code is outputed to browser and saved to file, otherwise only saved to file. It is effective only if $outfile is specified.
+        */
+        
         public static function png($text, $outfile = false, $level = QR_ECLEVEL_L, $size = 3, $margin = 4, $saveandprint=false) 
         {
             $enc = QRencode::factory($level, $size, $margin);
@@ -3095,6 +4617,17 @@
         }
 
         //----------------------------------------------------------------------
+        /**
+        Creates text (1's & 0's) containing QR-Code.
+        Simple helper function to create QR-Code text with one static call.
+        @param String $text text string to encode 
+        @param String $outfile (optional) output file name, when __false__ file is not saved
+        @param Integer $level (optional) error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $size (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $margin (optional) code margin (silent zone) in 'virtual'  pixels
+        @return Array containing line of code with 1 and 0 for every code line
+        */
+        
         public static function text($text, $outfile = false, $level = QR_ECLEVEL_L, $size = 3, $margin = 4) 
         {
             $enc = QRencode::factory($level, $size, $margin);
@@ -3102,25 +4635,162 @@
         }
 
         //----------------------------------------------------------------------
+        /**
+        Creates Raw Array containing QR-Code.
+        Simple helper function to create QR-Code array with one static call.
+        @param String $text text string to encode 
+        @param Boolean $outfile (optional) not used, shuold be __false__
+        @param Integer $level (optional) error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $size (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $margin (optional) code margin (silent zone) in 'virtual'  pixels
+        @return Array containing Raw QR code
+        */
+        
         public static function raw($text, $outfile = false, $level = QR_ECLEVEL_L, $size = 3, $margin = 4) 
         {
             $enc = QRencode::factory($level, $size, $margin);
             return $enc->encodeRAW($text, $outfile);
         }
+        
+        //----------------------------------------------------------------------
+        /**
+        Creates Html+JS code to draw  QR-Code with HTML5 Canvas.
+        Simple helper function to create QR-Code array with one static call.
+        @param String $text text string to encode 
+        @param String $elemId (optional) target Canvas tag id attribute, if __false__ Canvas tag with auto id will be created 
+        @param Integer $level (optional) error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $width (optional) CANVAS element width (sam as height)
+        @param Integer $size (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $margin (optional) code margin (silent zone) in 'virtual'  pixels
+        @param Boolean $autoInclude (optional) if __true__, required qrcanvas.js lib will be included (only once)
+        @return String containing JavaScript creating the code, Canvas element (when $elemId is __false__) and script tag with required lib (when $autoInclude is __true__ and not yet included)
+        */
+        
+        public static function canvas($text, $elemId = false, $level = QR_ECLEVEL_L, $width = false, $size = false, $margin = 4, $autoInclude = false) 
+        {
+            $html = '';
+            $extra = '';
+            
+            if ($autoInclude) {
+                if (!self::$jscanvasincluded) {
+                    self::$jscanvasincluded = true;
+                    echo '<script type="text/javascript" src="qrcanvas.js"></script>';
+                }
+            }
+            
+            $enc = QRencode::factory($level, 1, 0);
+            $tab_src = $enc->encode($text, false);
+            $area = new QRcanvasOutput($tab_src);
+            $area->detectGroups();
+            $area->detectAreas();
+            
+            if ($elemId === false) {
+                $elemId = 'qrcode-'.md5(mt_rand(1000,1000000).'.'.mt_rand(1000,1000000).'.'.mt_rand(1000,1000000).'.'.mt_rand(1000,1000000));
+                
+                if ($width == false) {
+                    if (($size !== false) && ($size > 0))  {
+                        $width = ($area->getWidth()+(2*$margin)) * $size;
+                    } else {
+                        $width = ($area->getWidth()+(2*$margin)) * 4;
+                    }
+                }
+                
+                $html .= '<canvas id="'.$elemId.'" width="'.$width.'" height="'.$width.'">Your browser does not support CANVAS tag! Please upgrade to modern version of FireFox, Opera, Chrome or Safari/Webkit based browser</canvas>';
+            }
+            
+            if ($width !== false) {
+                $extra .= ', '.$width.', '.$width;
+            } 
+                
+            if ($margin !== false) {
+                $extra .= ', '.$margin.', '.$margin;                
+            }
+            
+            $html .= '<script>if(eval("typeof "+\'QRdrawCode\'+"==\'function\'")){QRdrawCode(QRdecompactOps(\''.$area->getCanvasOps().'\')'."\n".', \''.$elemId.'\', '.$area->getWidth().' '.$extra.');}else{alert(\'Please include qrcanvas.js!\');}</script>';
+            
+            return $html;
+        }
+        
+        //----------------------------------------------------------------------
+        /**
+        Creates SVG with QR-Code.
+        Simple helper function to create QR-Code SVG with one static call.
+        @param String $text text string to encode 
+        @param Boolean $elemId (optional) target SVG tag id attribute, if __false__ SVG tag with auto id will be created 
+        @param String $outfile (optional) output file name, when __false__ file is not saved
+        @param Integer $level (optional) error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $width (optional) SVG element width (sam as height)
+        @param Integer $size (optional) pixel size, multiplier for each 'virtual' pixel
+        @param Integer $margin (optional) code margin (silent zone) in 'virtual'  pixels
+        @param Boolean $compress (optional) if __true__, compressed SVGZ (instead plaintext SVG) is saved to file
+        @return String containing SVG tag
+        */
+        
+        public static function svg($text, $elemId = false, $outFile = false, $level = QR_ECLEVEL_L, $width = false, $size = false, $margin = 4, $compress = false) 
+        {
+            $enc = QRencode::factory($level, 1, 0);
+            $tab_src = $enc->encode($text, false);
+            $area = new QRsvgOutput($tab_src);
+            $area->detectGroups();
+            $area->detectAreas();
+            
+            if ($elemId === false) {
+                $elemId = 'qrcode-'.md5(mt_rand(1000,1000000).'.'.mt_rand(1000,1000000).'.'.mt_rand(1000,1000000).'.'.mt_rand(1000,1000000));
+                
+                if ($width == false) {
+                    if (($size !== false) && ($size > 0))  {
+                        $width = ($area->getWidth()+(2*$margin)) * $size;
+                    } else {
+                        $width = ($area->getWidth()+(2*$margin)) * 4;
+                    }
+                }
+            }
+            
+            $svg = '<svg xmlns="http://www.w3.org/2000/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+            version="1.1"
+            baseProfile="full"
+            viewBox="'.(-$margin).' '.(-$margin).' '.($area->getWidth()+($margin*2)).' '.($area->getWidth()+($margin*2)).'" 
+            width="'.$width.'"
+            height="'.$width.'"
+            id="'.$elemId.'">'."\n";
+   
+            $svg .= $area->getRawSvg().'</svg>';
+   
+            if ($outFile !== false) {
+                $xmlPreamble = '<?xml version="1.0" encoding="UTF-8" standalone="no"'."\n";
+                $svgContent = $xmlPreamble.$svg;
+                
+                if ($compress === true) {
+                    file_put_contents($outFile, gzencode($svgContent));
+                } else {
+                    file_put_contents($outFile, $svgContent);
+                }
+            }
+            
+            return $svg;
+        }
     }
     
     //##########################################################################
+    /** Fills frame with data.
+    Each empty frame consist of markers, timing symbols and format configuration.
+    Remaining place is place for data, and should be filled according to QR Code spec.
+    */
+    class QRframeFiller {
     
-    class FrameFiller {
-    
-        public $width;
-        public $frame;
-        public $x;
-        public $y;
-        public $dir;
-        public $bit;
+        public $width; ///< __Integer__ Frame width
+        public $frame; ///< __Array__ Frame itself
+        public $x;     ///< __Integer__ current X position
+        public $y;     ///< __Integer__ current Y position
+        public $dir;   ///< __Integer__ direction
+        public $bit;   ///< __Integer__ bit
         
         //----------------------------------------------------------------------
+        /** Frame filler Constructor.
+        @param Integer $width frame size
+        @param Array $frame Frame array
+        */
         public function __construct($width, &$frame)
         {
             $this->width = $width;
@@ -3132,18 +4802,27 @@
         }
         
         //----------------------------------------------------------------------
+        /** Sets frame code at given position.
+        @param Array $at position, map containing __x__ and __y__ coordinates
+        @param Integer $val value to set
+        */
         public function setFrameAt($at, $val)
         {
             $this->frame[$at['y']][$at['x']] = chr($val);
         }
         
         //----------------------------------------------------------------------
+        /** Gets frame code from given position.
+        @param Array $at position, map containing __x__ and __y__ coordinates
+        @return Integer value at requested position
+        */
         public function getFrameAt($at)
         {
             return ord($this->frame[$at['y']][$at['x']]);
         }
         
         //----------------------------------------------------------------------
+        /** Proceed to next code point. */
         public function next()
         {
             do {
@@ -3200,22 +4879,29 @@
     } ;
     
     //##########################################################################    
-    
+    /** QR Code encoder.
+    Encoder is used by QRCode to create simple static code generators. */
     class QRencode {
     
-        public $casesensitive = true;
-        public $eightbit = false;
+        public $casesensitive = true; ///< __Boolean__ does input stream id case sensitive, if not encoder may use more optimal charsets
+        public $eightbit = false;     ///< __Boolean__ does input stream is 8 bit
         
-        public $version = 0;
-        public $size = 3;
-        public $margin = 4;
+        public $version = 0;          ///< __Integer__ code version (total size) if __0__ - will be auto-detected
+        public $size = 3;             ///< __Integer__ pixel zoom factor, multiplier to map virtual code pixels to image output pixels
+        public $margin = 4;           ///< __Integer__ margin (silent zone) size, in code pixels
         
-        public $structured = 0; // not supported yet
+        public $structured = 0;       ///< Structured QR codes. Not supported.
         
-        public $level = QR_ECLEVEL_L;
-        public $hint = QR_MODE_8;
+        public $level = QR_ECLEVEL_L; ///< __Integer__ error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        public $hint = QR_MODE_8;     ///< __Integer__ encoding hint, __QR_MODE_8__ or __QR_MODE_KANJI__, Because Kanji encoding is kind of 8 bit encoding we need to hint encoder to use Kanji mode explicite. (otherwise it may try to encode it as plain 8 bit stream)
         
         //----------------------------------------------------------------------
+        /** Encoder instances factory.
+        @param Integer $level error correction level __QR_ECLEVEL_L__, __QR_ECLEVEL_M__, __QR_ECLEVEL_Q__ or __QR_ECLEVEL_H__
+        @param Integer $size pixel zoom factor, multiplier to map virtual code pixels to image output pixels
+        @param Integer $margin margin (silent zone) size, in code pixels
+        @return builded QRencode instance
+        */
         public static function factory($level = QR_ECLEVEL_L, $size = 3, $margin = 4)
         {
             $enc = new QRencode();
@@ -3251,7 +4937,12 @@
         }
         
         //----------------------------------------------------------------------
-        public function encodeRAW($intext, $outfile = false) 
+        /** Encodes input into Raw code table.
+        @param String $intext input text
+        @param Boolean $notused (optional, not used) placeholder for similar outfile parameter
+        @return __Array__ Raw code frame
+        */
+        public function encodeRAW($intext, $notused = false) 
         {
             $code = new QRcode();
 
@@ -3265,6 +4956,11 @@
         }
 
         //----------------------------------------------------------------------
+        /** Encodes input into binary code table.
+        @param String $intext input text
+        @param String $outfile (optional) output file to save code table, if __false__ file will be not saved
+        @return __Array__ binary code frame
+        */
         public function encode($intext, $outfile = false) 
         {
             $code = new QRcode();
@@ -3277,15 +4973,21 @@
             
             QRtools::markTime('after_encode');
             
+            $binarized = QRtools::binarize($code->data);
             if ($outfile!== false) {
-                file_put_contents($outfile, join("\n", QRtools::binarize($code->data)));
-            } else {
-                return QRtools::binarize($code->data);
+                file_put_contents($outfile, join("\n", $binarized));
             }
+            
+            return $binarized;
         }
         
         //----------------------------------------------------------------------
-        public function encodePNG($intext, $outfile = false,$saveandprint=false) 
+        /** Encodes input into PNG image.
+        @param String $intext input text
+        @param String $outfile (optional) output file name, if __false__ outputs to browser with required headers
+        @param Boolean $saveandprint (optional) if __true__ code is outputed to browser and saved to file, otherwise only saved to file. It is effective only if $outfile is specified.
+        */
+        public function encodePNG($intext, $outfile = false, $saveandprint=false) 
         {
             try {
             
@@ -3309,4 +5011,5 @@
         }
     }
 
+    /** @}*/
 

--- a/seans-qrcode/plugin.php
+++ b/seans-qrcode/plugin.php
@@ -131,35 +131,35 @@ function sean_add_qrcode_css_head( $context ) {
 </style>
 <script type="text/javascript">
 jQuery(document).ready(function($) {
-   $('.button_qrcode').click(function() {
-     var NWin = window.open($(this).prop('href'), '', 'scrollbars=0,location=0,height=<?php echo SEAN_QR_WIDTH ?>,width=<?php echo SEAN_QR_WIDTH ?>');
-     if (window.focus)
-     {
-       NWin.focus();
-     }
-     return false;
-    });
+   sean_add_qr_popup($('.button_qrcode'));
     $('#main_table tbody').on("update", function() {
-        $('#main_table tbody tr:first td .button_qrcode').off("click").on("click", function() {
-           var NWin = window.open($(this).prop('href'), '', 'scrollbars=0,location=0,height=<?php echo SEAN_QR_WIDTH ?>,width=<?php echo SEAN_QR_WIDTH ?>');
-           if (window.focus) {
-             NWin.focus();
-           }
-           return false;
-        });
-<?php			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
-        var shorturl = $('#main_table tbody tr:first td.keyword a:first').attr('href').replace(/^http(s)?:\/\//, "//");
-        $('#sean_qr_img').attr( 'src', shorturl + '.qr' );
-<?php			endif; ?>
+      if($('#add-button').hasClass('loading')) {
+        sean_add_qr_popup($('#main_table tbody tr:first td .button_qrcode'));
+        var id = $('#main_table tbody tr:first').attr('id').replace(/^id-/, "");
+        sean_toggle_qr(id);
+      }
     });
 
 });
-<?php			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
+
+function sean_add_qr_popup(el) {
+    // need to do 'off' first because adding a URL triggers this twice and we don't want two identical actions added to click
+    el.off('click').on('click', function() {
+      var NWin = window.open($(this).attr('href'), '', 'scrollbars=0,location=0,height=<?php echo SEAN_QR_WIDTH ?>,width=<?php echo SEAN_QR_WIDTH ?>');
+      if (window.focus) {
+        NWin.focus();
+      }
+      return false;
+    });
+}
+
 function sean_toggle_qr(id) {
+<?php			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
     var shorturl = $('#keyword-'+id+' a:first').attr('href').replace(/^http(s)?:\/\//, "//");
     $('#sean_qr_img').attr( 'src', shorturl + '.qr' );
-}
 <?php			endif; ?>
+}
+
 </script>
 <?php
 		endif;

--- a/seans-qrcode/plugin.php
+++ b/seans-qrcode/plugin.php
@@ -184,10 +184,12 @@ function sean_add_qr_div($args) {
 $h = "h2";
 if( defined('YOURLS_INFOS') && YOURLS_INFOS) $h = "h3"; 
 $heading = "<$h>QR</$h>";
+$img = !empty($args[1])?$args[1] . '.qr':'';
+$img = yourls_match_current_protocol($img);
 ?>
 <div id="sean_qr_box" class="share">
 <?php echo $heading; ?>
-<img src="<?php echo !empty($args[1])?$args[1] . '.qr':'' ?>" id="sean_qr_img" alt="QR code" width="75px" />
+<img src="<?php echo $img; ?>" id="sean_qr_img" alt="QR code" width="75px" />
 </div>
 <?php
 }

--- a/seans-qrcode/plugin.php
+++ b/seans-qrcode/plugin.php
@@ -139,9 +139,22 @@ jQuery(document).ready(function($) {
      }
      return false;
     });
+    $('#main_table tbody').on("update", function() {
+        $('#main_table tbody tr:first td .button_qrcode').off("click").on("click", function() {
+           var NWin = window.open($(this).prop('href'), '', 'scrollbars=0,location=0,height=<?php echo SEAN_QR_WIDTH ?>,width=<?php echo SEAN_QR_WIDTH ?>');
+           if (window.focus) {
+             NWin.focus();
+           }
+           return false;
+        });
+<?php			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
+        var shorturl = $('#main_table tbody tr:first td.keyword a:first').attr('href').replace(/^http(s)?:\/\//, "//");
+        $('#sean_qr_img').attr( 'src', shorturl + '.qr' );
+<?php			endif; ?>
+    });
+
 });
-<?php
-			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
+<?php			if( SEAN_QR_ADD_TO_SHAREBOX ): ?>
 function sean_toggle_qr(id) {
     var shorturl = $('#keyword-'+id+' a:first').attr('href').replace(/^http(s)?:\/\//, "//");
     $('#sean_qr_img').attr( 'src', shorturl + '.qr' );

--- a/seans-qrcode/plugin.php
+++ b/seans-qrcode/plugin.php
@@ -181,9 +181,12 @@ if (SEAN_QR_ADD_TO_SHAREBOX) {
 
 /* Add the extra HTML for the QR code to the share boxe */
 function sean_add_qr_div($args) {
+$h = "h2";
+if( defined('YOURLS_INFOS') && YOURLS_INFOS) $h = "h3"; 
+$heading = "<$h>QR</$h>";
 ?>
 <div id="sean_qr_box" class="share">
-<h2>QR</h2>
+<?php echo $heading; ?>
 <img src="<?php echo !empty($args[1])?$args[1] . '.qr':'' ?>" id="sean_qr_img" alt="QR code" width="75px" />
 </div>
 <?php


### PR DESCRIPTION
This change add support for generating SVG QR codes, along with several other changes. The latest version of phpqrcode is used to facilitate SVG support
- Option to generate QR codes in SVG format. A default format can be set, which can be overridden by appending `.svg` or `.png` to the code's URL
- QR code can optionally be displayed in the share boxes area
- When clicking the QR button from the admin area, the QR code is opened in a new window, sized to the code
- Several options can be set in `user\config.php`
